### PR TITLE
gchq/stroom#3335 preserve escape chars not preceding delimiters

### DIFF
--- a/stroom-pipeline/src/test/java/stroom/pipeline/xml/converter/ds3/TestDS3.java
+++ b/stroom-pipeline/src/test/java/stroom/pipeline/xml/converter/ds3/TestDS3.java
@@ -263,6 +263,39 @@ class TestDS3 extends StroomUnitTest {
     }
 
     @Test
+    void testLocation_singleLine2() throws IOException, SAXException {
+        final RootFactory rootFactory = new RootFactory();
+        final SplitFactory splitFactory = new SplitFactory(
+                rootFactory,
+                "split",
+                0,
+                -1,
+                null,
+                "=",
+                "\\",
+                null,
+                null);
+        new DataFactory(splitFactory, "rowData", "row", "$3");
+
+        rootFactory.compile();
+
+        final Root root = rootFactory.newInstance(new VarMap());
+
+        final String inputStr = "flexString1=test\\nmessage\\=123";
+
+        final LoggingContentHandler loggingContentHandler = doLocationTest(
+                root,
+                inputStr,
+                List.of(makeRange(1, 1, 1, 12),
+                        makeRange(1, 13, 1, 30)));
+
+        Assertions.assertThat(loggingContentHandler.getValues())
+                .containsExactly(
+                        "flexString1",
+                        "test\\nmessage=123");
+    }
+
+    @Test
     void testLocation_singleLine_contained_2charDelim() throws IOException, SAXException {
         final RootFactory rootFactory = new RootFactory();
         final SplitFactory splitFactory = new SplitFactory(

--- a/stroom-pipeline/src/test/java/stroom/pipeline/xml/converter/ds3/TestSplitMatcher.java
+++ b/stroom-pipeline/src/test/java/stroom/pipeline/xml/converter/ds3/TestSplitMatcher.java
@@ -28,7 +28,7 @@ class TestSplitMatcher extends StroomUnitTest {
     private static final String TESTDATA = "" +
             ",692289,2012-08-28 09:56:00,2012-08-28 09:56:00,\"562\",8,Suc\"c\"ess Audit event,  \"3\" ,  " +
             "\"Objec\"t\" Access\"  ,   Secur\"ity,Sec\"urity   |5676|1144|C:\\WINNT\\system32\\svchost.exe," +
-            "CODE123/,NT AUTHORITY\\SYSTEM,   \"  Handle Closed,  \"  \": Ob/,ject \" Se,rver: " +
+            "CODE123/,NT AUTHORITY\\SYSTEM,   \"  Handle/Closed,  \"  \": Ob/,ject \" Se,rver: " +
             "Security Handle ID: 5676 Process ID: 1144 Image File Name: C:\\WINNT\\system32\\svchost.exe ,\n";
     private static final char[] TESTARR = TESTDATA.toCharArray();
 
@@ -110,6 +110,8 @@ class TestSplitMatcher extends StroomUnitTest {
                 .isEqualTo("2012-08-28 09:56:00");
         assertThat(match.filter(input, 2).toString())
                 .isEqualTo("2012-08-28 09:56:00");
+        assertThat(match.filter(input, 3).toString())
+                .isEqualTo("2012-08-28 09:56:00");
 
         input.move(match.end());
         match = split.match();
@@ -119,6 +121,8 @@ class TestSplitMatcher extends StroomUnitTest {
         assertThat(match.filter(input, 1).toString())
                 .isEqualTo("562");
         assertThat(match.filter(input, 2).toString())
+                .isEqualTo("562");
+        assertThat(match.filter(input, 3).toString())
                 .isEqualTo("562");
 
         input.move(match.end());
@@ -130,6 +134,8 @@ class TestSplitMatcher extends StroomUnitTest {
                 .isEqualTo("8");
         assertThat(match.filter(input, 2).toString())
                 .isEqualTo("8");
+        assertThat(match.filter(input, 3).toString())
+                .isEqualTo("8");
 
         input.move(match.end());
         match = split.match();
@@ -139,6 +145,8 @@ class TestSplitMatcher extends StroomUnitTest {
         assertThat(match.filter(input, 1).toString())
                 .isEqualTo("Suc\"c\"ess Audit event");
         assertThat(match.filter(input, 2).toString())
+                .isEqualTo("Suc\"c\"ess Audit event");
+        assertThat(match.filter(input, 3).toString())
                 .isEqualTo("Suc\"c\"ess Audit event");
 
         input.move(match.end());
@@ -150,6 +158,8 @@ class TestSplitMatcher extends StroomUnitTest {
                 .isEqualTo("3");
         assertThat(match.filter(input, 2).toString())
                 .isEqualTo("3");
+        assertThat(match.filter(input, 3).toString())
+                .isEqualTo("3");
 
         input.move(match.end());
         match = split.match();
@@ -159,6 +169,8 @@ class TestSplitMatcher extends StroomUnitTest {
         assertThat(match.filter(input, 1).toString())
                 .isEqualTo("Objec\"t\" Access");
         assertThat(match.filter(input, 2).toString())
+                .isEqualTo("Objec\"t\" Access");
+        assertThat(match.filter(input, 3).toString())
                 .isEqualTo("Objec\"t\" Access");
 
         input.move(match.end());
@@ -170,6 +182,8 @@ class TestSplitMatcher extends StroomUnitTest {
                 .isEqualTo("Secur\"ity,Sec\"urity   |5676|1144|C:\\WINNT\\system32\\svchost.exe");
         assertThat(match.filter(input, 2).toString())
                 .isEqualTo("Secur\"ity,Sec\"urity   |5676|1144|C:\\WINNT\\system32\\svchost.exe");
+        assertThat(match.filter(input, 3).toString())
+                .isEqualTo("Secur\"ity,Sec\"urity   |5676|1144|C:\\WINNT\\system32\\svchost.exe");
 
         input.move(match.end());
         match = split.match();
@@ -180,16 +194,20 @@ class TestSplitMatcher extends StroomUnitTest {
                 .isEqualTo("CODE123/,NT AUTHORITY\\SYSTEM");
         assertThat(match.filter(input, 2).toString())
                 .isEqualTo("CODE123,NT AUTHORITY\\SYSTEM");
+        assertThat(match.filter(input, 3).toString())
+                .isEqualTo("CODE123,NT AUTHORITY\\SYSTEM");
 
         input.move(match.end());
         match = split.match();
 
         assertThat(match.filter(input, 0).toString())
-                .isEqualTo("   \"  Handle Closed,  \"  \": Ob/,ject \" Se,");
+                .isEqualTo("   \"  Handle/Closed,  \"  \": Ob/,ject \" Se,");
         assertThat(match.filter(input, 1).toString())
-                .isEqualTo("Handle Closed,  \"  \": Ob/,ject \" Se");
+                .isEqualTo("Handle/Closed,  \"  \": Ob/,ject \" Se");
         assertThat(match.filter(input, 2).toString())
-                .isEqualTo("Handle Closed,  \"  \": Ob,ject \" Se");
+                .isEqualTo("HandleClosed,  \"  \": Ob,ject \" Se");
+        assertThat(match.filter(input, 3).toString())
+                .isEqualTo("Handle/Closed,  \"  \": Ob,ject \" Se");
 
     }
 }

--- a/unreleased_changes/20251008_151133_677__3335.md
+++ b/unreleased_changes/20251008_151133_677__3335.md
@@ -1,0 +1,60 @@
+* Issue **#3335** : Preserve escape chars not preceding delimiters.
+
+
+```sh
+# ********************************************************************************
+# Issue title: Add opt-in data splitter `split` option to change escape behaviour
+# Issue link:  https://github.com/gchq/stroom/issues/3335
+# ********************************************************************************
+
+# ONLY the top line will be included as a change entry in the CHANGELOG.
+# The entry should be in GitHub flavour markdown and should be written on a SINGLE
+# line with no hard breaks. You can have multiple change files for a single GitHub issue.
+# The  entry should be written in the imperative mood, i.e. 'Fix nasty bug' rather than
+# 'Fixed nasty bug'.
+#
+# Examples of acceptable entries are:
+#
+#
+# * Issue **123** : Fix bug with an associated GitHub issue in this repository
+#
+# * Issue **namespace/other-repo#456** : Fix bug with an associated GitHub issue in another repository
+#
+# * Fix bug with no associated GitHub issue.
+
+
+# --------------------------------------------------------------------------------
+# The following is random text to make this file unique for git's change detection
+# Y0rIkb7DfdpLZtf2GZBKa5YlSBdkXPgRXS9glbTsJosV2tChpn5leSkKmekajQ422QDtFAI0uKK2Qn9t
+# ltHPnJ7TAv1f9caAjRgm3vO3JG6uNG85h2mHXWAPaDxQMVsfqyF5tPfAiJO7nITYqQjZT7SP7T3lWHmM
+# I4NCTj3qcePZYfnhm0byZvmviNqEuCVV8aLSQK52DZYswTRqySqEOWyiGXDl4RerhN9et2DmMKlxsYsu
+# xN9DsNjD2LPy6tHnOkl4nV4raTKdcmmDyqRlDhDa1lCn8T99mcOxvh8c9Q7Joud1LK5UtJ2oBM4xXTfg
+# L8dt08VR5n3oPTVDbSqTEeyaddJ0jmm2yG6VgYRxKfa7iWVxUv4FQ10uDwlso5GK4YaZeELVzDKI3HwV
+# SNucSg3ReQazXiZh1NyP37blfzq7jRgOjegU2IfceOQ23hadkeu7bu29MYwl0rQTSFwSQBws8G2CRJZi
+# wNEkvFYgpuEGiul5f8IxbhsVL35okPpyvknc5kYPcyi0fgXYATHiWnhwS2aC9nfYgSFZFQj5D9XjsT6A
+# icHmocPWLze9zBAjfekCwVHXUW5EtrCWFdwPMnIHA0Z0whw2fjhK37hkBMaInVpQwkJl1jYwEOjw4GTc
+# qM6bkiqg3pVQ0RFPwNXheZ5OfzyMOaxhM7lkT783a2rK6MeLKXAscGMdfZm2XOBV014pqgnPX79HRrYX
+# 2368KFhiZuI8AxkonIutafDR0H2FWbdy4tfC0oTRLL9oJ2g8l766MVckZzmG2nTJlo6Fk7SOQxjFPfdn
+# rttcTkyXjVjhXnNihpz8FhYcd5Uiu5OVjuSIovlYRXQQRQ2KnrglkmYvVX90qhjGalnWobwoD5BKRHb3
+# 1zEhnwKGEcNvqMiaBKKmsnhSaxIR38rjIU9mP0K4rod586WIW3WqBqEpbpMFPhSs9CNKzYTmv50nVZ8e
+# FC9xrQGJ5cDfUpGXsrNfecTg6MMHeq0W0lwp3nydJJypwV4cfVRwE5tANb6fM4WpzZYtURIiPTvo7ciX
+# PSdFBdSEzxvaGTR3udv4ILbhZGc5ZZpVTfqPYKlaDhqBu30Fw51s7pUqefo1tMas1LA3lF1ENR0XdYnR
+# ULXdaztsIZYZxX9SttAokHwok1oyhPEFiYVkfkJUbO7Hk8UC81SpnCeZSGf9gKLZzTfu7sQwfpXZpDwT
+# GBy6RgSynuCXZwj46SegIHR2oHO4nDQtGj0JCsGd5L86hCClw05rq04mEjLMltgXlaqKesfDjoD50GFC
+# ckEVkDLTZSHoxRGtRBuYIHWQjVjcwlgzBL1SlQikluK7Ruybm8CF3u66KgOm8CyA4EnRS57gkNy7fAB1
+# 3DyRk0pjfKdsO35p11K2loeRhOdu2iM570j45MCI3fNs3bZJoHn95gmoImJzii4EoyNuCVdIVN0SDMAP
+# OBTN3DHTNb0sUHjGRwsh48FKTws0Jgo6PrEzBcoYKmkfHufv7e6ezKaSrsnI69i9kJZxwjJi7IXOnaiN
+# SS2nV0J9nU7bWc5i9MMAecHFVekwgImRSMk5xuFhCuYCxAuqou77MKcnkaMtLUxYhgaI5fuvQerbdsXI
+# ANESzch0dLv2ja5r85W4iQiAiBNehBYtkiH01hnNsvHI6nmwSGEBFinZHFnP7fRIWmou9k861fWTwqaS
+# g79ZwcqzQKX7AFjPSUTwuBWnm5e2y5UUPDjSdaOV4nyocSh3CFWV7yZX2m087lwIxRaKTMQc64iIGHZh
+# ND9QqZl3HammGqumx045QvfUWLAUN7kVkce3Gr6Cvn4sf9JE9ytHaniWYgSUMi7ym2lkbawXCSmwiy2a
+# KarmV4wT4HQD45mznwpqTJEhmTERSqZL9ZSkwwp7Twaj0mrakQzDEdlFHhbY1CTcupW6c0HIziCA0Zot
+# 7Qql5iiHO8VNnUnADIz1H7L2352tRl1dqAjzfTwwGOBtfKOemCNXpzXAytbs7eLKriDI7Hr8nKA5fM8q
+# sFl5LzEVoaKpV7CPXR5QY27VVIiKzAXEQuJURWhVhlY96HdjRaa0JTIILYtjPuKy66cRB0BuYMFsmkpy
+# KCPPCU3RNybNilO0QoGcgVR4o8JDhcK3qFQsaqWhoDchvQrHjgpGLpKXgn0qs9qrmGSm0RPCKma0Hv3E
+# 9FgXQI8l28WWgNE7Q7STCeRvRQjNPQJCuGpGFyZLgDCyDVFNwBjD2qamwzzC26fCcwAfA97SuiXWR2cs
+# UwBOKP4vGkiVSCIPAYVQozCLS31g98ddZfjN3GO0EIb4JitL7a8OJyTNOxLOC8ztf9Uin0v8jkBT5BO3
+# LoSatT8ZtlI4vSAdpGlSkO1bzGRkPtTr0ilxoNeZaL8vmrb4fbMXFvrUEBUqh6gTEGANR5GURET4mjWl
+# --------------------------------------------------------------------------------
+
+```


### PR DESCRIPTION
to enable change in escape behaviour use group 3, for example

```
<dataSplitter>
  <split id="split" delimiter="=" escape="\">
    <data id="rowData" name="row" value="$3" />
  </split>
</dataSplitter>
```